### PR TITLE
fix: apply prettier config at the very end to disable all required rules

### DIFF
--- a/__snapshots__/preset.test.ts.snap
+++ b/__snapshots__/preset.test.ts.snap
@@ -21,8 +21,8 @@ exports[`should have a correct configuration for a React file 1`] = `
     "unused-imports",
     "simple-import-sort",
     "import",
-    "prettier",
     "@typescript-eslint",
+    "prettier",
     "react-hooks",
     "react",
   ],
@@ -92,7 +92,7 @@ exports[`should have a correct configuration for a React file 1`] = `
       "off",
     ],
     "@typescript-eslint/no-extra-semi": [
-      "error",
+      "off",
     ],
     "@typescript-eslint/no-inferrable-types": [
       "error",
@@ -1003,9 +1003,9 @@ exports[`should have a correct configuration for a TypeScript file 1`] = `
     "unused-imports",
     "simple-import-sort",
     "import",
-    "prettier",
     "@typescript-eslint",
     "jest",
+    "prettier",
   ],
   "reportUnusedDisableDirectives": undefined,
   "rules": {
@@ -1073,7 +1073,7 @@ exports[`should have a correct configuration for a TypeScript file 1`] = `
       "off",
     ],
     "@typescript-eslint/no-extra-semi": [
-      "error",
+      "off",
     ],
     "@typescript-eslint/no-inferrable-types": [
       "error",
@@ -1097,11 +1097,6 @@ exports[`should have a correct configuration for a TypeScript file 1`] = `
       "error",
       {
         "paths": [
-          {
-            "allowTypeImports": true,
-            "message": "Please only use Providers instantiated in constants/providers to improve traceability.",
-            "name": "@ethersproject/providers",
-          },
           {
             "message": "Please import from '@ethersproject/module' directly to support tree-shaking.",
             "name": "ethers",

--- a/node.js
+++ b/node.js
@@ -5,8 +5,8 @@ module.exports = {
     es6: true,
     node: true,
   },
-  plugins: ['prettier', 'import', 'simple-import-sort', 'unused-imports'],
-  extends: ['eslint:recommended', 'plugin:prettier/recommended'],
+  plugins: ['import', 'simple-import-sort', 'unused-imports'],
+  extends: ['eslint:recommended'],
   parserOptions: {
     sourceType: 'module',
   },
@@ -59,6 +59,11 @@ module.exports = {
       },
       extends: ['plugin:jest/recommended'],
       plugins: ['jest'],
+    },
+    {
+      files: ['*'],
+      plugins: ['prettier'],
+      extends: ['plugin:prettier/recommended'],
     },
   ],
 }


### PR DESCRIPTION
Prettier should be applied as a very last rule to make sure all rules (such as ones defined by `typescript-eslint`) are disabled and do not cause issues.

**Context:**

Prettier ESLint plugin includes an ESLint config that disables all potentially conflicting ESLint rules that are already handled by Prettier. A great example is `@typescript-eslint/no-extra-semi`. 

ESLint allows to extend multiple configs via `extends` array. We need to make sure Prettier config is the very last config in that array, otherwise some plugins may accidentally re-enable conflicting rules.

A great example is when Typescript ESLint config is loaded after Prettier config and it re-enables some rules, such as `@typescript-eslint/no-extra-semi`. You can see the difference in a configuration snapshot after changing the order of elements in the array.