### PR TITLE
chore: add missing `load.js` file to npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "files": [
     "restrictedImports.js",
     "node.js",
-    "react.js"
+    "react.js",
+    "load.js"
   ],
   "dependencies": {
     "@rushstack/eslint-patch": "^1.2.0",


### PR DESCRIPTION
As per PR title, `load.js` file was missing from npm package