### PR TITLE
feat: specify ecmaVersion

### DIFF
--- a/node.js
+++ b/node.js
@@ -8,6 +8,7 @@ module.exports = {
   plugins: ['import', 'simple-import-sort', 'unused-imports'],
   extends: ['eslint:recommended'],
   parserOptions: {
+    ecmaVersion: 2020,
     sourceType: 'module',
   },
   rules: {

--- a/react.js
+++ b/react.js
@@ -8,6 +8,7 @@ module.exports = {
   },
   plugins: ['react', 'react-hooks'],
   parserOptions: {
+    ecmaVersion: 2020,
     ecmaFeatures: {
       jsx: true,
     },

--- a/react.js
+++ b/react.js
@@ -8,7 +8,6 @@ module.exports = {
   },
   plugins: ['react', 'react-hooks'],
   parserOptions: {
-    ecmaVersion: 2020,
     ecmaFeatures: {
       jsx: true,
     },


### PR DESCRIPTION
Specifies an `ecmaVersion` >=2018 to allow the spread operator, otherwise linter gives errors.